### PR TITLE
add downloadUrl property to DriveItem model

### DIFF
--- a/src/Services/MicrosoftDriveService.php
+++ b/src/Services/MicrosoftDriveService.php
@@ -71,7 +71,8 @@ class MicrosoftDriveService
                 $response->name,
                 $response->webUrl,
                 $this->config->getSharePointUserSpaceName(),
-                $this->config->getSharePointBaseUrl()
+                $this->config->getSharePointBaseUrl(),
+                $response->{'@microsoft.graph.downloadUrl'}
             );
         } catch (ClientExceptionInterface $e) {
             throw new MicrosoftRequestException($e->getMessage(), $e->getCode());

--- a/src/ValueObject/MicrosoftDriverItem.php
+++ b/src/ValueObject/MicrosoftDriverItem.php
@@ -41,13 +41,19 @@ final class MicrosoftDriverItem
      */
     private $baseUrl;
 
+    /**
+     * @var null|string
+     */
+    private $downloadUrl;
+
     public function __construct(
         string $id,
         string $eTag,
         string $name,
         string $webUrl,
         string $userSpace,
-        string $baseUrl
+        string $baseUrl,
+        string $downloadUrl = null
     ) {
         $this->id = $id;
         $this->eTag = $eTag;
@@ -57,6 +63,7 @@ final class MicrosoftDriverItem
         $this->baseUrl = $baseUrl;
 
         $this->configure();
+        $this->downloadUrl = $downloadUrl;
     }
 
     /**
@@ -86,6 +93,20 @@ final class MicrosoftDriverItem
     public function getEmbedUrl(): string
     {
         return $this->embedUrl;
+    }
+
+    /**
+     * @param bool $withTempAuth
+     *
+     * @return null|string
+     */
+    public function getDownloadUrl(bool $withTempAuth = true): ?string
+    {
+        if (!$withTempAuth) {
+            return $this->downloadUrl;
+        }
+
+        return preg_replace('/&tempauth(=[^&]*)?|^foo(=[^&]*)?&?/', '', $this->downloadUrl);
     }
 
     private function configure(): void

--- a/src/ValueObject/MicrosoftDriverItem.php
+++ b/src/ValueObject/MicrosoftDriverItem.php
@@ -96,17 +96,16 @@ final class MicrosoftDriverItem
     }
 
     /**
-     * @param bool $withTempAuth
-     *
      * @return null|string
      */
-    public function getDownloadUrl(bool $withTempAuth = true): ?string
+    public function getDownloadUrl(): ?string
     {
-        if (!$withTempAuth) {
-            return $this->downloadUrl;
-        }
-
         return preg_replace('/&tempauth(=[^&]*)?|^foo(=[^&]*)?&?/', '', $this->downloadUrl);
+    }
+
+    public function getDownloadUrlWithTmpAuthParameter(): ?string
+    {
+        return $this->downloadUrl;
     }
 
     private function configure(): void


### PR DESCRIPTION
Added new property called downloadUrl to DriveItem model.

This addition is necessary because the DriveItem should be composed by embed, web and download URLs.